### PR TITLE
【优化】优化前端界面显示

### DIFF
--- a/source/page/Clinic.tsx
+++ b/source/page/Clinic.tsx
@@ -37,15 +37,16 @@ export class ClinicPage extends mixin<{}, ClinicPageState>() {
     render(_, { loading, list }: ClinicPageState) {
         return (
             <SpinnerBox cover={loading}>
-                <h2>义诊服务</h2>
+                <header className="d-flex justify-content-between align-item-center my-3">
+                    <h2>义诊服务</h2>
+                </header>
 
                 <Table center striped hover>
                     <thead>
                         <tr>
-                            <th>机构/个人名</th>
-                            <th>官网网址</th>
-                            <th>联系人（姓名、电话）</th>
-                            <th>每日接诊起止时刻</th>
+                            <th>机构 / 个人</th>
+                            <th>联系方式</th>
+                            <th>接诊时间</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -60,7 +61,6 @@ export class ClinicPage extends mixin<{}, ClinicPageState>() {
                                         name
                                     )}
                                 </td>
-                                <td className="text-nowrap">{url}</td>
                                 <td className="text-nowrap">{contacts}</td>
                                 <td className="text-nowrap">{time}</td>
                             </tr>

--- a/source/page/Factory/index.tsx
+++ b/source/page/Factory/index.tsx
@@ -22,7 +22,7 @@ interface FactoryPageState {
     renderTarget: 'children'
 })
 export class FactoryPage extends mixin<{}, FactoryPageState>() {
-    state = { loading: false, noMore: false };
+    state = { loading: true, noMore: false };
 
     loadMore = async ({ detail }: EdgeEvent) => {
         if (detail !== 'bottom' || this.state.noMore) return;

--- a/source/page/Hotel/index.tsx
+++ b/source/page/Hotel/index.tsx
@@ -22,7 +22,7 @@ interface HotelPageState {
 })
 export class HotelPage extends mixin<{}, HotelPageState>() {
     state = {
-        loading: false,
+        loading: true,
         noMore: false
     };
 

--- a/source/page/Logistics/index.tsx
+++ b/source/page/Logistics/index.tsx
@@ -37,19 +37,14 @@ export class LogisticsPage extends mixin<{}, LogisticsPageState>() {
     render(_, { loading, list, noMore }: LogisticsPageState) {
         return (
             <SpinnerBox cover={loading}>
-                <div className="container">
-                    <div className="row">
-                        <h2 className="col-auto mr-auto">物流公司</h2>
-                        <div className="col-auto">
-                            <Button
-                                className=" btn btn-success"
-                                href="logistics/edit"
-                            >
-                                物流发布
-                            </Button>
-                        </div>
-                    </div>
-                </div>
+                <header className="d-flex justify-content-between align-item-center my-3">
+                    <h2>物流公司</h2>
+                    <span>
+                        <Button kind="success" href="logistics/edit">
+                        物流发布
+                        </Button>
+                    </span>
+                </header>
 
                 <edge-detector onTouchEdge={this.loadMore}>
                     <Table center striped hover>
@@ -82,7 +77,7 @@ export class LogisticsPage extends mixin<{}, LogisticsPageState>() {
                                                 name
                                             )}
                                         </td>
-                                        <td className="text-nowrap">
+                                        <td className="text-nowrap text-left">
                                             {serviceArea.map(
                                                 ({
                                                     city,
@@ -132,14 +127,12 @@ export class LogisticsPage extends mixin<{}, LogisticsPageState>() {
                                                 <div
                                                     style={{ padding: '5px 0' }}
                                                 >
-                                                    <Button
-                                                        className="btn btn-primary"
-                                                        href={
-                                                            'tel:' + item.phone
-                                                        }
+                                                    <a 
+                                                        className="text-center text-decoration-none"
+                                                        href={ 'tel:' + item.phone }
                                                     >
-                                                        {item.name}
-                                                    </Button>
+                                                        <i className="fa fa-phone btn btn-lg btn-primary" aria-hidden="true" />
+                                                    </a>
                                                 </div>
                                             ))}
                                         </td>


### PR DESCRIPTION
### 📝changelog
1. 将义诊服务、物流公司的标题统一格式。
2. 精简义诊服务的列表表头；同时企业/个人可直接点击进入官网网址，故此项去除。
3. 修复工厂、酒店的起始 loading 状态。
4. 将物流公司的电话修改为图标形式；优化物流区域的显示。