### PR TITLE
[Bug] 医院需求项目数字为1时，应显示为不限数量

### DIFF
--- a/source/page/Hospital/index.tsx
+++ b/source/page/Hospital/index.tsx
@@ -108,14 +108,23 @@ export class HospitalPage extends mixin<{}, HospitalPageState>() {
                 title={hospital}
             >
                 <ol>
-                    {supplies.map(({ name, count, remark }) => (
-                        <li title={remark}>
-                            {name}{' '}
-                            <span className="badge badge-danger">
-                                {count}个
-                            </span>
-                        </li>
-                    ))}
+                    {supplies.map(({ name, count, remark }) => {
+                        let n = +count;
+                        let showCount = '';
+                        if (n === 1) {
+                            showCount = '数量不限';
+                        } else {
+                            showCount = count + '个';
+                        }
+                        return (
+                            <li title={remark}>
+                                {name}{' '}
+                                <span className="badge badge-danger">
+                                    {showCount}
+                                </span>
+                            </li>
+                        );
+                    })}
                 </ol>
 
                 <div className="text-center">


### PR DESCRIPTION
增加判断count为1时，调整展示为数量不限。

后续如果增加数量待确认，也可在这里增加逻辑