### PR TITLE
[bugfix]省市区筛选“全部”bug(#54)

### DIFF
--- a/source/page/Hotel/index.tsx
+++ b/source/page/Hotel/index.tsx
@@ -22,7 +22,7 @@ interface HotelPageState {
 })
 export class HotelPage extends mixin<{}, HotelPageState>() {
     state = {
-        loading: true,
+        loading: false,
         noMore: false
     };
 

--- a/source/page/Logistics/index.tsx
+++ b/source/page/Logistics/index.tsx
@@ -25,7 +25,7 @@ const DIREACTION = {
     renderTarget: 'children'
 })
 export class LogisticsPage extends mixin<{}, LogisticsPageState>() {
-    state = { loading: true, noMore: false };
+    state = { loading: false, noMore: false };
 
     loadMore = async ({ detail }: EdgeEvent) => {
         if (detail !== 'bottom' || this.state.noMore) return;

--- a/source/service/AMap.ts
+++ b/source/service/AMap.ts
@@ -1,6 +1,7 @@
 const key = '8325164e247e15eea68b59e89200988b';
 
 async function requestAMap<T = {}>(path: string, data: any): Promise<T> {
+    if(path === 'config/district' && data.keywords === '全部') data.keywords = '中国';
     const response = await fetch(
         `//restapi.amap.com/v3/${path}?${new URLSearchParams({ ...data, key })}`
     );


### PR DESCRIPTION
筛选菜单“省”选择“全部”时，keywords的值应当是“中国”