### PR TITLE
feat: 增加疫情地图

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "mobx": "^5.15.4",
         "mobx-web-cell": "^0.2.5",
         "web-cell": "^2.0.0-rc.15",
+        "wuhan2020-map-viz": "git+https://github.com/wuhan2020/map-viz.git",
         "yaml": "^1.7.2"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "mobx": "^5.15.4",
         "mobx-web-cell": "^0.2.5",
         "web-cell": "^2.0.0-rc.15",
-        "wuhan2020-map-viz": "git+https://github.com/wuhan2020/map-viz.git",
+        "wuhan2020-map-viz": "git+https://github.com/allenfantasy/map-viz.git#fix-responsive-issue",
         "yaml": "^1.7.2"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "mobx": "^5.15.4",
         "mobx-web-cell": "^0.2.5",
         "web-cell": "^2.0.0-rc.15",
-        "wuhan2020-map-viz": "git+https://github.com/allenfantasy/map-viz.git#fix-responsive-issue",
+        "wuhan2020-map-viz": "git+https://github.com/wuhan2020/map-viz.git",
         "yaml": "^1.7.2"
     },
     "devDependencies": {

--- a/source/page/Maps.tsx
+++ b/source/page/Maps.tsx
@@ -16,6 +16,9 @@ interface MapPageState {
 }
 
 const resolution = 3600000 * 24;
+const isMobile = navigator.userAgent.match(
+    /(phone|pad|pod|iPhone|iPod|ios|iPad|Android|Mobile|BlackBerry|IEMobile|MQQBrowser|JUC|Fennec|wOSBrowser|BrowserNG|WebOS|Symbian|Windows Phone)/i
+);
 
 @component({
     tagName: 'maps-page',
@@ -28,60 +31,44 @@ export class MapsPage extends mixin<{}, MapPageState>() {
         super.connectedCallback();
 
         // Here are the data where I find form issue #56, if the api-server has the data, plz change
-        const list: Map[] = [
-            {
-                name: '丁香园',
-                url: 'https://ncov.dxy.cn/ncovh5/view/pneumonia'
-            },
-            {
-                name: '腾讯',
-                url: 'https://news.qq.com/zt2020/page/feiyan.htm'
-            },
-            {
-                name: '百度',
-                url: 'https://voice.baidu.com/act/newpneumonia/newpneumonia'
-            },
-            {
-                name: '微脉',
-                url: 'https://m.myweimai.com/topic/epidemic_info.html'
-            },
-        ];
+        // const list: Map[] = [
+        //     {
+        //         name: '丁香园',
+        //         url: 'https://ncov.dxy.cn/ncovh5/view/pneumonia'
+        //     },
+        //     {
+        //         name: '腾讯',
+        //         url: 'https://news.qq.com/zt2020/page/feiyan.htm'
+        //     },
+        //     {
+        //         name: '百度',
+        //         url: 'https://voice.baidu.com/act/newpneumonia/newpneumonia'
+        //     },
+        //     {
+        //         name: '微脉',
+        //         url: 'https://m.myweimai.com/topic/epidemic_info.html'
+        //     },
+        // ];
 
-        await this.setState({ loading: false, list });
+        await this.setState({ loading: false });
     }
 
     render(_, { loading }: MapPageState) {
+        const mapContainerStyle: any = {
+            width: '100%'
+        };
+        if (isMobile) {
+            mapContainerStyle.height = 'calc(100vh - 60px)';
+        } else {
+            mapContainerStyle.height = 'calc(100vh - 100px)';
+        }
         return (
-            <div style={{ width: '100%', height: 'calc(100vh - 100px)' }}>
+            <div style={mapContainerStyle}>
                 <SpinnerBox cover={loading}>
                     <HierarchicalVirusMap
                         data={VirusData}
                         resolution={resolution}
                     />
-                    {/* <Table center striped hover>
-                        <thead>
-                            <tr>
-                                <th>地图来源</th>
-                                <th>地图链接</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {list.map(({ name, url }: Map) => (
-                                <tr>
-                                    <td className="text-nowrap">
-                                        {url ? (
-                                            <a target="_blank" href={url}>
-                                                {name}
-                                            </a>
-                                        ) : (
-                                            name
-                                        )}
-                                    </td>
-                                    <td className="text-nowrap">{url}</td>
-                                </tr>
-                            ))}
-                        </tbody>
-                    </Table> */}
                 </SpinnerBox>
             </div>
         );

--- a/source/page/Maps.tsx
+++ b/source/page/Maps.tsx
@@ -1,6 +1,9 @@
+// eslint-disable-next-line no-unused-vars
 import { component, createCell, mixin } from 'web-cell';
+// eslint-disable-next-line no-unused-vars
 import { SpinnerBox } from 'boot-cell/source/Prompt/Spinner';
-import { Table } from 'boot-cell/source/Content/Table';
+// eslint-disable-next-line no-unused-vars
+import { VirusData, HierarchicalVirusMap } from 'wuhan2020-map-viz';
 
 interface Map {
     name: string;
@@ -12,11 +15,13 @@ interface MapPageState {
     list?: Map[];
 }
 
+const resolution = 3600000 * 24;
+
 @component({
     tagName: 'maps-page',
     renderTarget: 'children'
 })
-export class MapsPage extends mixin<{}, ClinicPageState>() {
+export class MapsPage extends mixin<{}, MapPageState>() {
     state = { loading: true, list: [] };
 
     async connectedCallback() {
@@ -45,38 +50,40 @@ export class MapsPage extends mixin<{}, ClinicPageState>() {
         await this.setState({ loading: false, list });
     }
 
-    render(_, { loading, list }: MapPageState) {
+    render(_, { loading }: MapPageState) {
         return (
-            <SpinnerBox cover={loading}>
-                <header className="d-flex justify-content-between align-item-center my-3">
-                    <h2>疫情地图</h2>
-                </header>
-
-                <Table center striped hover>
-                    <thead>
-                        <tr>
-                            <th>地图来源</th>
-                            <th>地图链接</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {list.map(({ name, url }: Map) => (
+            <div style={{ width: '100%', height: 'calc(100vh - 100px)' }}>
+                <SpinnerBox cover={loading}>
+                    <HierarchicalVirusMap
+                        data={VirusData}
+                        resolution={resolution}
+                    />
+                    {/* <Table center striped hover>
+                        <thead>
                             <tr>
-                                <td className="text-nowrap">
-                                    {url ? (
-                                        <a target="_blank" href={url}>
-                                            {name}
-                                        </a>
-                                    ) : (
-                                        name
-                                    )}
-                                </td>
-                                <td className="text-nowrap">{url}</td>
+                                <th>地图来源</th>
+                                <th>地图链接</th>
                             </tr>
-                        ))}
-                    </tbody>
-                </Table>
-            </SpinnerBox>
+                        </thead>
+                        <tbody>
+                            {list.map(({ name, url }: Map) => (
+                                <tr>
+                                    <td className="text-nowrap">
+                                        {url ? (
+                                            <a target="_blank" href={url}>
+                                                {name}
+                                            </a>
+                                        ) : (
+                                            name
+                                        )}
+                                    </td>
+                                    <td className="text-nowrap">{url}</td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </Table> */}
+                </SpinnerBox>
+            </div>
         );
     }
 }

--- a/source/service/mapData.ts
+++ b/source/service/mapData.ts
@@ -1,0 +1,27 @@
+// 疫情数据接口
+// NOTE 由于访问接口地址并不是和系统对应的接口是同一服务 所以单独起一个服务
+import { request } from 'koajax';
+const baseUri = 'http://wuhan2020.org.cn/data/map-viz';
+
+type ValidType = 'overall' | 'current' | 'history';
+
+export const getVirusMapData = async (type: ValidType = 'overall') => {
+    const uri = `${baseUri}/${type}.json`;
+
+    try {
+        const response = await request({
+            method: 'GET',
+            path: uri,
+            responseType: 'json'
+        }).response;
+        const { status, statusText, body } = response;
+        if (status === 200) {
+            return body;
+        } else {
+            throw new Error(`api return error! ${statusText}`);
+        }
+    } catch (e) {
+        console.warn('error!!!', e);
+        return null;
+    }
+};


### PR DESCRIPTION
组件来自 map team 提供的 [组件](https://github.com/wuhan2020/map-viz/tree/web-cell)

### TODO

- [x] 直接从数据接口获取最新的疫情数据，不依赖于组件自带的数据（实时性不够）

fix #13 