### PR TITLE
chore(tsconfig): upgrade TypeScript target to ES2020 and drop IE 11

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
         "*.{html,md,less,json,yml,js,mjs,ts,tsx}": "prettier --write",
         "*.{js,mjs,ts,tsx}": "eslint --fix"
     },
-    "browserslist": "> 0.5%, last 2 versions, not dead, IE 11",
+    "browserslist": "> 0.5%, last 2 versions, not dead",
     "scripts": {
         "e": "pnpx @dotenvx/dotenvx run -f .env.personal.local -- pnpm",
         "prepare": "husky",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "target": "ES6",
+        "target": "ES2020",
         "module": "ESNext",
         "moduleResolution": "Node",
         "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
## 改动

- `tsconfig.json`: `target` 从 `ES6` 升级到 `ES2020`
- `package.json`: browserslist 移除 `IE 11`

## 原因

- IE 11 已停止支持，且项目使用的 Web Components、Service Worker 等特性 IE 11 均不支持
- 升级 target 后 TypeScript 不再注入 `__generator` 等 helper，产物体积更小
- Parcel 通过 swc 按 browserslist 做最终降级，不影响实际兼容性

Closes #104