### PR TITLE
ci(main): upgrade checkout to v7 and vercel-action to v42

### DIFF
--- a/.github/workflows/image-action.yml
+++ b/.github/workflows/image-action.yml
@@ -8,7 +8,7 @@ jobs:
     name: calibreapp/image-actions
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: calibreapp/image-actions
         uses: docker://calibreapp/github-image-actions

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: pnpm/action-setup@v4
         with:
@@ -38,7 +38,7 @@ jobs:
           force_orphan: true
 
       - name: Deploy to Vercel
-        uses: amondnet/vercel-action@v25
+        uses: amondnet/vercel-action@de09aeac2ace6599ec9b11ef87558759a496bac4 # v42.3.0
         if: ${{ env.VERCEL_TOKEN && env.VERCEL_ORG_ID && env.VERCEL_PROJECT_ID }}
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
## 改动

- `actions/checkout@v4` → `@3d3c42e` (# v7.0.1)
- `amondnet/vercel-action@v25` → `@de09aea` (# v42.3.0)
- 使用 commit hash 固定版本，防止 tag 被篡改

Closes #106